### PR TITLE
Update the alias check.

### DIFF
--- a/tests/errors/alias-swap-1.ja
+++ b/tests/errors/alias-swap-1.ja
@@ -1,0 +1,5 @@
+procedure main()
+  int a[2] = {1,2}
+
+  a[0] <=> a[0]  // a[0] on the both hand sides.
+

--- a/tests/errors/alias-swap-2.ja
+++ b/tests/errors/alias-swap-2.ja
@@ -1,0 +1,5 @@
+procedure main()
+  int a[2] = {1,2}
+
+  a[0] <=> a[a[0]]  // a[0] on the both hand sides.
+  a[0] <=> a[a[0]]


### PR DESCRIPTION
The following aliases are not allowed:

procedure main()
  int a[2] = {1,2}

  a[0] <=> a[a[0]]
  a[0] <=> a[a[0]]